### PR TITLE
Fix color update order in click handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
     const cores = ['#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6'];
     
     titulo.addEventListener('click', function() {
-        cliques++;
         titulo.style.color = cores[cliques % cores.length];
+        cliques++;
         status.textContent = `Status: ${cliques} cliques de progresso! 🚀`;
     });
     


### PR DESCRIPTION
## Summary
- Adjust click handler to apply color before incrementing click count
- Ensure status message still reflects the incremented click count

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aa08a90c832a80622e1bc0f935ac